### PR TITLE
fix: update ppa link

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ QRB ROS system monitors includes various ROS 2 nodes to publish informations wit
 Add Qualcomm IOT PPA for Ubuntu:
 
 ```bash
-sudo add-apt-repository ppa:ubuntu-qcom-iot/qcom-noble-ppa
+sudo add-apt-repository ppa:ubuntu-qcom-iot/qcom-ppa
 sudo add-apt-repository ppa:ubuntu-qcom-iot/qirp
 sudo apt update
 ```


### PR DESCRIPTION
## Summary

- Update the Qualcomm Ubuntu PPA in README from qcom-noble-ppa to qcom-ppa for release/1.1.3.

## Test

- Not run; documentation-only change.